### PR TITLE
Api update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,25 @@ Bind the state of form controls or fieldsets to checkboxes and radio buttons.
 Include the shackle.js file on a page. Then invoke it as so:
 
 ```javascript
-Shackle.pair('id-of-enabling-control', 'id-of-affected-control', boolean);
+Shackle.pair({
+    enabler: 'box1',
+    affected: 'controls1',
+    whenChecked: ['readonly'],
+    whenUnchecked: ['disabled', 'hidden']
+});
 ```
 
-The first argument is an enabling control. This is intended to be a radio
-button or checkbox. If it has the checked attribute, it will alter the
-state of the second argument, the affected control.
-
-By default, when you check the enabling control, the affected control
-becomes enabled. You can alter this behavior with the third argument.
-If the third argument is false, the affected control will only be disabled
-when the state of the enabling control is not checked. If it is true, it will 
-also be hidden when the enabling control is not checked.
+The configuration object is simple:
+- enabler: the enabler is the if of the form control that will alter the
+  state of other markup. It must be able to gain/lose the "checked" HTML 
+  attribute to trigger the state change on the corresponding affected markup.
+- affected: this is the id of some HTML on the page that you want to alter
+  when the state of the enabler control changes. It can be anything, though
+  I designed this with fieldsets in mind. It's very useful selectively
+  disable a whole fieldset based on a checkbox. For instance, the the fieldset
+  is asking for information on an opt-in basis, why not hide it and disable it
+  unless an opt-in checkbox is checked?
+- whenChecked: a list of HTML attributes to apply when the state of the enabler
+  is checked.
+- whenUnchecked: a list of HTML attributes to apply when the state of the
+  enabler is not checked

--- a/shackle.js
+++ b/shackle.js
@@ -3,42 +3,68 @@
 * fieldset's enabled/disabled state to the checked/unchecked
 * state of a radio button or checkbox.
 * Simply Include Shackle and call:
-* Shackle.pair(id-of-enabling-element, id-of-affected-element);
+* Shackle.pair({
+*   enabler: 'id-of-enabling-control',
+*   affected: 'id-of-affected-control',
+*   whenChecked: [
+*       'propertyname'
+*   ],
+*   whenUnchecked: [
+*       'propertyname'
+*   ]);
 */
 var Shackle = (function(document, window) {
-  //Make any change to the state of the enabling
-  //control cause the other controls to syncronize
-  //their state
-  var pair = function(enableId, controlId, hideControls) {
-    if (hideControls == undefined) {
-      hideControls = false;
-    }
-    console.log(enableId, controlId);
-    var enable = document.getElementById(enableId);
-    console.log(enable);
-    var control = document.getElementById(controlId);
-    console.log(control);
-    enable.addEventListener('click',
-                             _sync.bind(null, enable, control, hideControls),
-                             false);
-    _sync(enable, control, hideControls);
-  };
   
-  //Synchronize the current state of the enabling control
-  //to the enabled/disabled control(s)
-  var _sync = function(enable, control, hideControls) {
-    if(enable.checked) {
-      control.disabled = false;
-      if (hideControls) {
-        control.hidden = false;
-      }
+    /**
+     * Add an event listener for the enabler that synchronizes
+     * the whenChecked and whenUnchecked properties of the
+     * affected markup with the current state of the enabler.
+     * It also performs the initial state synchronization.
+     */
+  var pair = function(config) {
+      //ensure configuration is legal
+    if (! (config.hasOwnProperty('enabler')
+            && config.hasOwnProperty('affected')
+            && (config.hasOwnProperty('whenChecked')
+                || config.hasOwnProperty('whenUnchecked')))) {
+        return;
+    }
+    var enabler = document.getElementById(config['enabler']);
+    var affected = document.getElementById(config['affected']);
+    var whenChecked = (config['whenChecked'] != undefined
+            ? config['whenChecked'] : []);
+    var whenUnchecked = (config['whenUnchecked'] != undefined
+            ? config['whenUnchecked'] : []);
+    enabler.addEventListener('change',
+            _sync.bind(null, enabler, affected, whenChecked, whenUnchecked),
+            false);
+    _sync(enabler, affected, whenChecked, whenUnchecked);
+  };
+
+  /**
+   * Synchronize the state of the enabler to the affected markup.
+   * This applies the whenChecked properties if the enabler is checked,
+   * and the whenUnchecked properties when it is not.
+   */
+  var _sync = function(enabler, affected, whenChecked, whenUnchecked) {
+    if (enabler.checked) {
+        whenChecked.forEach(function applyProperty(property) {
+           affected[property] = true; 
+        });
+        whenUnchecked.forEach(function applyProperty(property) {
+           affected[property] = false; 
+        });
     } else {
-      control.disabled = true;
-      if (hideControls) {
-        control.hidden = true;
-      } 
+        whenChecked.forEach(function applyProperty(property) {
+           affected[property] = false; 
+        });
+        whenUnchecked.forEach(function applyProperty(property) {
+           affected[property] = true; 
+        });
     }
   };
+
+  //return the public API
   return {
     pair: pair
   };


### PR DESCRIPTION
Resolve #3, #2, and #1  by accepting an object-based configuration that doesn't make assumptions about which properties should be 'true' when the enabler is checked.
